### PR TITLE
Use 'generic' Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,16 +41,9 @@
 dist: trusty
 sudo: required
 language:
-  - python
+  - generic
 cache:
   - apt
-
-# By default travis runs all python code in a virtualenv that does not contain
-# the packages installed with apt-get. As this is essential (pip doesn't contain
-# all the necessary ROS python packages), tell travis-ci to use the system-wide
-# python packages.
-virtualenv:
-  system_site_packages: true
 
 # Configuration variables. All variables are global now, but this can be used to
 # trigger a build matrix for different ROS distributions if desired.

--- a/ros_pkg_with_tests/scripts/double.py
+++ b/ros_pkg_with_tests/scripts/double.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 def double(x):
     """
 
@@ -7,4 +9,4 @@ def double(x):
     :param x:
     :return:
     """
-    return 2 * x
+    return np.multiply(2, x)

--- a/ros_pkg_with_tests/scripts/test/test_double.py
+++ b/ros_pkg_with_tests/scripts/test/test_double.py
@@ -3,6 +3,7 @@
 import unittest
 import rospy
 import rostest
+import numpy as np
 
 from scripts.double import double
 
@@ -19,6 +20,13 @@ class TestCase(unittest.TestCase):
     def test_good_math(self):
         ret = double(3)
         self.assertEqual(6, ret)
+
+    def test_double_vector(self):
+        x = np.array([2, 5])
+        ret = double(x)
+        ref = np.array([4, 10])
+        self.assertTrue(np.array_equal(ref, ret))
+
 
 if __name__ == '__main__':
     rostest.rosrun('package_name', 'test_name', TestCase)


### PR DESCRIPTION
The generic travis configuration prevents the numpy import issue in Travis (https://github.com/travis-ci/travis-ci/issues/4948).
