### PR TITLE
Fix CI script by manually setting PYTHONPATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,9 @@ env:
     - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
     - CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
     - ROS_PARALLEL_JOBS='-j8 -l6'
+    # Set the python path manually to include /usr/-/python2.7/dist-packages
+    # as this is where apt-get installs python packages.
+    - PYTHONPATH=$PYTHONPATH:/usr/lib/python2.7/dist-packages:/usr/local/lib/python2.7/dist-packages
 
 ################################################################################
 


### PR DESCRIPTION
During an ubuntu image upgrade on Travis' side (specifically from
connie-trusty to sugilite-trusty, see [here]), the python binary is
installed into /opt/python/2.7.13 and the python search path is
updated accordingly.

However, since all ROS dependencies are installed by apt-get into
/usr/lib/python2.7 , this commit adds that location to the PYTHONPATH
environment variable to ensure that python is able to find all
required packages installed via apt-get.

This addresses the issue where the Travis build failed due to an
import error:

    ImportError: "from catkin_pkg.package import parse_package" failed
    No module named catkin_pkg.package

This package was indeed installed, just inside

    /usr/lib/python2.7/dist-packages/catkin_pkg

Fixes #9 

  [here]: https://docs.travis-ci.com/user/build-environment-updates/2017-07-12/