### PR TITLE
Update dpkg before installing ROS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
   - sudo apt-get update -qq
+  - sudo apt-get install dpkg
   - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.


### PR DESCRIPTION
An error occurs during ROS installation when using an out of date
version of dpkg. Update the dpkg package to prevent this error.

Source: https://github.com/ros-infrastructure/catkin_pkg/issues/227