### PR TITLE
Change dependency to something available on kinetic.

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -5,5 +5,5 @@
 # add all repositories from an existing workspace, you can use `wstool scrape`.
 
 - git:
-    local-name: pocketsphinx
-    uri: https://github.com/felixduvallet/pocketsphinx.git
+    local-name: grasp-synergy
+    uri: https://github.com/felixduvallet/grasp-synergy.git

--- a/ros_pkg_with_dependencies/package.xml
+++ b/ros_pkg_with_dependencies/package.xml
@@ -14,7 +14,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>audio_common_msgs</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>pocketsphinx</build_depend>
+  <build_depend>grasp_synergy</build_depend>
   <run_depend>audio_common_msgs</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
Remove the rosinstall (from source) dependency on pocketsphinx,
because that package is not compatible with ROS kinetic. Add a
different dependency on a package which will be cloned from github.

Make no changes to the .travis.yml file.