### PR TITLE
Enable ROS kinetic support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,20 +39,23 @@
 
 ################################################################################
 
-# Use ubuntu trusty (14.04) with sudo privileges.
-dist: trusty
 sudo: required
-language:
-  - generic
 cache:
   - apt
 
+# Build all valid Ubuntu/ROS combinations available on Travis VMs.
+language: generic
 matrix:
   include:
-  - name: "ROS indigo"
+  - name: "Trusty indigo"
+    dist: trusty
     env: ROS_DISTRO=indigo
-  - name: "ROS jade"
+  - name: "Trusty jade"
+    dist: trusty
     env: ROS_DISTRO=jade
+  - name: "Xenial kinetic"
+    dist: xenial
+    env: ROS_DISTRO=kinetic
 
 # Configuration variables. All variables are global now, but this can be used to
 # trigger a build matrix for different ROS distributions if desired.
@@ -75,7 +78,7 @@ before_install:
   - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
   - sudo apt-get update -qq
   - sudo apt-get install dpkg
-  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin
+  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ROS package continuous integration with travis.
+# ROS package continuous integration with travis (now supporting Kinetic).
 
 This repository contains a [.travis.yml](https://github.com/felixduvallet/ros-travis-integration/blob/master/.travis.yml)
 file for setting up continuous integration (through Travis-CI) for any ROS package.
@@ -73,6 +73,21 @@ repository into the workspace before building anything.
 When building your own package, make sure to remove the contents of
 dependencies.rosinstall and add your package's source dependencies instead.
 
+# Build matrix
+
+The .travis.yml defines a build matrix specifying which combinations of Ubuntu
+distribution and ROS version should be used.
+
+Currently, the list of supported pairs is:
+
+ - ROS indigo on Ubuntu trusty
+ - ROS jade on Ubuntu trusty
+ - ROS kinetic on Ubuntu xenial
+
+Note that some pairs are not possible (e.g. kinetic on trusty or indigo/jade on
+xenial). The debian packages must be available for the appropriate ubuntu
+release.
+
 # ROS variables:
 
 The .travis.yml file has some [environment
@@ -80,9 +95,6 @@ variables](https://docs.travis-ci.com/user/environment-variables/) you can
 change to customize your build: defined in the script which are used to
 parametrize the build:
 
-  - ROS_DISTRO (indigo or jade are suppored, default is indigo): Note that
-    packages must be available for ubuntu 14.04 trusty, so kinetic is not
-    supported at this time (work in progress).
   - ROSINSTALL_FILE (default is dependencies.rosinstall in repo): This file
     list all necessary repositories in wstool format (see the ros wiki). If the
     file does not exists then nothing happens.


### PR DESCRIPTION
Update the build matrix to include ROS kinetic. Kinetic is only
available on Ubuntu xenial (16.04), not trusty. Note that indigo and
jade are *not* supported on xenial.

This requires a small change to the package installation list
(ros-base instead of catkin).