### PR TITLE
Update repository authentication keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,6 @@ matrix:
   - name: "Trusty indigo"
     dist: trusty
     env: ROS_DISTRO=indigo
-  - name: "Trusty jade"
-    dist: trusty
-    env: ROS_DISTRO=jade
   - name: "Xenial kinetic"
     dist: xenial
     env: ROS_DISTRO=kinetic

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ env:
 # Install system dependencies, namely a very barebones ROS setup.
 before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+  - sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
   - sudo apt-get update -qq
   - sudo apt-get install dpkg
   - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-ros-base

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
 # trigger a build matrix for different ROS distributions if desired.
 env:
   global:
-    - ROS_CI_DESKTOP="`lsb_release -cs`"  # e.g. [precise|trusty|...]
+    - ROS_CI_DESKTOP="`lsb_release -cs`"  # e.g. [trusty|xenial|...]
     - CI_SOURCE_PATH=$(pwd)
     - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
     - CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
@@ -82,7 +82,7 @@ before_install:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init
-  - rosdep update
+  - rosdep update --include-eol-distros
 
 # Create a catkin workspace with the package under integration.
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ before_install:
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep to install dependencies.
   - sudo rosdep init
-  - rosdep update --include-eol-distros
+  - rosdep update --include-eol-distros  # Support EOL distros.
 
 # Create a catkin workspace with the package under integration.
 install:

--- a/README.md
+++ b/README.md
@@ -81,10 +81,9 @@ distribution and ROS version should be used.
 Currently, the list of supported pairs is:
 
  - ROS indigo on Ubuntu trusty
- - ROS jade on Ubuntu trusty
  - ROS kinetic on Ubuntu xenial
 
-Note that some pairs are not possible (e.g. kinetic on trusty or indigo/jade on
+Note that some pairs are not possible (e.g. kinetic on trusty or indigo on
 xenial). The debian packages must be available for the appropriate ubuntu
 release.
 


### PR DESCRIPTION
The apt keyserver for ROS deb packages has changed. Update the
repository authentication keys to match those found in the
installation documentation.